### PR TITLE
Mark NIO helper function as internal to support compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "ff01888051cd7efceb1bf8319c1dd3986c4bf6fc",
-          "version": "2.10.1"
+          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
+          "version": "2.14.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/wickwirew/Runtime.git",
         "state": {
           "branch": null,
-          "revision": "c167476b07fe8cc65fdf064076a4081c3269d14a",
-          "version": "2.1.0"
+          "revision": "61c9776f47d2951bdc562486ad348e5e1ca2e180",
+          "version": "2.1.1"
         }
       },
       {
@@ -24,17 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
-          "version": "1.14.1"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
+          "revision": "ff01888051cd7efceb1bf8319c1dd3986c4bf6fc",
+          "version": "2.10.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "GraphQL", targets: ["GraphQL"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.10.1")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.13.1")),
         .package(url: "https://github.com/wickwirew/Runtime.git", .upToNextMinor(from: "2.1.0"))
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "GraphQL", targets: ["GraphQL"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "1.14.1")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.10.1")),
         .package(url: "https://github.com/wickwirew/Runtime.git", .upToNextMinor(from: "2.1.0"))
     ],
     targets: [

--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -74,7 +74,7 @@ public func graphql(
     let validationErrors = validate(instrumentation: instrumentation, schema: schema, ast: documentAST)
 
     guard validationErrors.isEmpty else {
-        return eventLoopGroup.next().newSucceededFuture(result: GraphQLResult(errors: validationErrors))
+        return eventLoopGroup.next().makeSucceededFuture(GraphQLResult(errors: validationErrors))
     }
 
     return execute(
@@ -128,7 +128,7 @@ public func graphql<Retrieval: PersistedQueryRetrieval>(
     case .parseError(let parseError):
         throw parseError
     case .validateErrors(_, let validationErrors):
-        return eventLoopGroup.next().newSucceededFuture(result: GraphQLResult(errors: validationErrors))
+        return eventLoopGroup.next().makeSucceededFuture(GraphQLResult(errors: validationErrors))
     case .result(let schema, let documentAST):
         return execute(
             queryStrategy: queryStrategy,

--- a/Sources/GraphQL/Type/Definition.swift
+++ b/Sources/GraphQL/Type/Definition.swift
@@ -557,7 +557,7 @@ public struct GraphQLField {
         
         self.resolve = { source, args, context, eventLoopGroup, info in
             let result = try resolve(source, args, context, info)
-            return eventLoopGroup.next().newSucceededFuture(result: result)
+            return eventLoopGroup.next().makeSucceededFuture(result)
         }
     }
 }

--- a/Sources/GraphQL/Type/Introspection.swift
+++ b/Sources/GraphQL/Type/Introspection.swift
@@ -445,7 +445,7 @@ let SchemaMetaFieldDef = GraphQLFieldDefinition(
     type: GraphQLNonNull(__Schema),
     description: "Access the current type schema of this server.",
     resolve: { _, _, _, eventLoopGroup, info in
-        return eventLoopGroup.next().newSucceededFuture(result: info.schema)
+        return eventLoopGroup.next().makeSucceededFuture(info.schema)
     }
 )
 
@@ -461,7 +461,7 @@ let TypeMetaFieldDef = GraphQLFieldDefinition(
     ],
     resolve: { _, arguments, _, eventLoopGroup, info in
         let name = arguments["name"].string!
-        return eventLoopGroup.next().newSucceededFuture(result: info.schema.getType(name: name))
+        return eventLoopGroup.next().makeSucceededFuture(info.schema.getType(name: name))
     }
 )
 
@@ -470,6 +470,6 @@ let TypeNameMetaFieldDef = GraphQLFieldDefinition(
     type: GraphQLNonNull(GraphQLString),
     description: "The name of the current Object type at runtime.",
     resolve: { _, _, _, eventLoopGroup, info in
-        eventLoopGroup.next().newSucceededFuture(result: info.parentType.name)
+        eventLoopGroup.next().makeSucceededFuture(info.parentType.name)
     }
 )

--- a/Sources/GraphQL/Utilities/NIO+Extensions.swift
+++ b/Sources/GraphQL/Utilities/NIO+Extensions.swift
@@ -11,13 +11,13 @@ import NIO
 public typealias Future = EventLoopFuture
 
 extension Collection {
-    public func flatten<T>(on eventLoopGroup: EventLoopGroup) -> Future<[T]> where Element == Future<T> {
+    internal func flatten<T>(on eventLoopGroup: EventLoopGroup) -> Future<[T]> where Element == Future<T> {
         return Future.whenAll(Array(self), eventLoop: eventLoopGroup.next())
     }
 }
 
 extension Collection {
-    public func flatMap<S, T>(
+    internal func flatMap<S, T>(
         to type: T.Type,
         on eventLoopGroup: EventLoopGroup,
         _ callback: @escaping ([S]) throws -> Future<T>
@@ -55,7 +55,7 @@ extension Dictionary where Value : FutureType {
     }
 }
 extension Future {
-    public func flatMap<T>(
+    internal func flatMap<T>(
         to type: T.Type = T.self,
         _ callback: @escaping (Expectation) throws -> Future<T>
     ) -> Future<T> {

--- a/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
+++ b/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
@@ -23,7 +23,7 @@ class FieldExecutionStrategyTests: XCTestCase {
                         }
                         
                         group.wait()
-                        return eventLoopGroup.next().newSucceededFuture(result: "z")
+                        return eventLoopGroup.next().makeSucceededFuture("z")
                     }
                 ),
                 "bang": GraphQLField(
@@ -55,7 +55,7 @@ class FieldExecutionStrategyTests: XCTestCase {
                         
                         g.wait()
                         
-                        return eventLoopGroup.next().newFailedFuture(error: StrategyError.exampleError(
+                        return eventLoopGroup.next().makeFailedFuture(StrategyError.exampleError(
                             msg: "\(info.fieldName): \(info.path.elements.last!)"
                         ))
                     }


### PR DESCRIPTION
The declarations of some NIO extension functions can close clash with functions of other packages (In this case Vapor). By marking them as internal the functionality stays the same but also adds cross package compatibility.